### PR TITLE
ATLAS-4777: Only append reference text if the current text doesn't al…

### DIFF
--- a/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
+++ b/jasperreports/src/net/sf/jasperreports/util/ReferenceCreator.java
@@ -185,9 +185,12 @@ public class ReferenceCreator {
             for (Map<String, String> refEntry : references) {
                 if (refEntry.get(REFERENCE_KEY).equals(referenceKey)) {
                     String currentText = refEntry.get(REFERENCE_TEXT);
-                    refEntry.put(REFERENCE_TEXT,
-                            String.join("\n", prependAdditional ? referenceText : currentText,
-                                    prependAdditional ? currentText : referenceText));
+                    // If Detail Split Type == "Prevent" then we get double calls, hence the need to check that the
+                    // currentText doesn't already contain the reference Text.
+                    if (!currentText.contains(referenceText)) {
+                        refEntry.put(REFERENCE_TEXT, String.join("\n", prependAdditional ? referenceText : currentText,
+                                prependAdditional ? currentText : referenceText));
+                    }
                     return referenceKey;
                 }
             }


### PR DESCRIPTION
…ready contain the reference text. This is to avoid duplicate entries in references where an element has been processed twice after the rendering engine determines that a split-type "Prevent" detail must be shifted to a new page to prevent detail split.